### PR TITLE
Use unionId instead of openId

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rake"
+gem "rake", "~> 11.3.0"
 gem 'byebug'
 
 gemspec

--- a/lib/omniauth/strategies/wechat.rb
+++ b/lib/omniauth/strategies/wechat.rb
@@ -21,7 +21,7 @@ module OmniAuth
       end
 
       uid do
-        raw_info['openid']
+        raw_info['unionid']
       end
 
       info do
@@ -31,7 +31,8 @@ module OmniAuth
           province:   raw_info['province'],
           city:       raw_info['city'],
           country:    raw_info['country'],
-          headimgurl: raw_info['headimgurl']
+          headimgurl: raw_info['headimgurl'],
+          openid:     raw_info['openid']
         }
       end
 
@@ -47,13 +48,12 @@ module OmniAuth
       end
 
       def raw_info
-        @uid ||= access_token["openid"]
         @raw_info ||= begin
           access_token.options[:mode] = :query
           if access_token["scope"]&.include?("snsapi_login")
-            access_token.get("/sns/userinfo", :params => { "openid" => @uid, "lang" => "zh_CN" }, parse: :json).parsed
+            access_token.get("/sns/userinfo", :params => { "openid" => access_token["openid"], "lang" => "zh_CN" }, parse: :json).parsed
           else
-            { "openid" => @uid }
+            { "unionid" => access_token["unionid"], "openid" => access_token["openid"] }
           end
         end
         @raw_info

--- a/spec/omniauth/strategies/wechat_spec.rb
+++ b/spec/omniauth/strategies/wechat_spec.rb
@@ -100,19 +100,21 @@ describe OmniAuth::Strategies::Wechat do
     context "when scope is snsapi_base" do
       let(:access_token) { OAuth2::AccessToken.from_hash(client, {
         "openid"=>"openid", 
+        "unionid" => "unionid",
         "scope"=>"snsapi_base", 
         "access_token"=>"access_token"
       })}
 
       specify "only have openid" do
-        expect(subject.uid).to eq("openid")
-        expect(subject.raw_info).to eq("openid" => "openid")
+        expect(subject.uid).to eq("unionid")
+        expect(subject.raw_info).to eq("openid" => "openid", "unionid" => "unionid")
       end
     end
 
     context "when scope is snsapi_login" do
       let(:access_token) { OAuth2::AccessToken.from_hash(client, {
         "openid"=>"openid", 
+        "unionid" => "unionid",
         "scope"=>"snsapi_login", 
         "access_token"=>"access_token"
       })}
@@ -126,6 +128,7 @@ describe OmniAuth::Strategies::Wechat do
         end.and_return(double("response", parsed: 
           {
             openid: "OPENID",
+            unionid: "UNIONID",
             nickname: "NICKNAME",
             sex: "1",
             province: "PROVINCE",
@@ -138,6 +141,7 @@ describe OmniAuth::Strategies::Wechat do
         expect(subject.raw_info).to eq(
           {
             openid: "OPENID",
+            unionid: "UNIONID",
             nickname: "NICKNAME",
             sex: "1",
             province: "PROVINCE",


### PR DESCRIPTION
Unlike the openId the unionId is stable accross applications.

As often one application has several WeChat applications e.g. for Android, iOS and Web
the unionId should get used otherwise a user which signed up on e.g. Android can not signup
with the same WeChat account on Web or iOS as it would have a different openID for each
of these applications.

> OpenID is an unique encrypted WeChat ID for each user of an OA (including Mini Program).

> UnionID is an unique ID to identify a single user under the same WeChat open platform account.
If a developer possesses multiple mobile applications, website applications, and OAs (including Mini Programs),
they can use a UnionID to differentiate the uniqueness of users.
In other words, UnionID offers a mechanism for developers to acquire a user’s data from multiple
platforms and attribute actions back to the specific user.

https://wiredcraft.com/blog/wechat-for-dummies-user-data-and-authorization/
https://stackoverflow.com/questions/40044572/wechat-open-platform-openid-and-unionid

This change would break existing users of the strategy as we change the `uid` attribute.
However, I don't think there is a way to make this backward compatible :thinking:.