### PR TITLE
Add image field to user info hash

### DIFF
--- a/lib/omniauth/strategies/wechat.rb
+++ b/lib/omniauth/strategies/wechat.rb
@@ -32,6 +32,7 @@ module OmniAuth
           city:       raw_info['city'],
           country:    raw_info['country'],
           headimgurl: raw_info['headimgurl'],
+          image:      raw_info['headimgurl'],
           unionid:    raw_info['unionid']
         }
       end

--- a/spec/omniauth/strategies/wechat_spec.rb
+++ b/spec/omniauth/strategies/wechat_spec.rb
@@ -125,26 +125,41 @@ describe OmniAuth::Strategies::Wechat do
           expect(opts[:parse]).to eq(:json)
         end.and_return(double("response", parsed: 
           {
-            openid: "OPENID",
-            nickname: "NICKNAME",
-            sex: "1",
-            province: "PROVINCE",
-            city: "CITY",
-            country: "COUNTRY",
-            headimgurl: "header_image_url",
-            privilege: ["PRIVILEGE1", "PRIVILEGE2"]
+            "openid" => "OPENID",
+            "nickname" => "NICKNAME",
+            "sex" => "1",
+            "province" => "PROVINCE",
+            "city" => "CITY",
+            "country" => "COUNTRY",
+            "headimgurl" => "header_image_url",
+            "privilege" => ["PRIVILEGE1", "PRIVILEGE2"],
+            "unionid" => "UNIONID"
           }
         ))
+
         expect(subject.raw_info).to eq(
           {
-            openid: "OPENID",
+            "openid" => "OPENID",
+            "nickname" => "NICKNAME",
+            "sex" => "1",
+            "province" => "PROVINCE",
+            "city" => "CITY",
+            "country" => "COUNTRY",
+            "headimgurl" => "header_image_url",
+            "privilege" => ["PRIVILEGE1", "PRIVILEGE2"],
+            "unionid" => "UNIONID"
+          }
+        )
+        expect(subject.info).to eq(
+          {
             nickname: "NICKNAME",
             sex: "1",
             province: "PROVINCE",
             city: "CITY",
             country: "COUNTRY",
             headimgurl: "header_image_url",
-            privilege: ["PRIVILEGE1", "PRIVILEGE2"]
+            image: "header_image_url",
+            unionid: "UNIONID"
           }
         )
       end


### PR DESCRIPTION
The `headimgurl` field should get normalized to `image` according to the omniauth schema.

> This information is meant to be as normalized as possible, so the schema below will be filled to the greatest degree available given the provider upon authentication. Fields marked required will always be present. Note that this guide may also be useful to developers implementing custom strategies to know how to provide results.

https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema

This also adds some specs for the changes in #21 