### PR TITLE
Fix directory structure

### DIFF
--- a/lib/omniauth-wechat-oauth2.rb
+++ b/lib/omniauth-wechat-oauth2.rb
@@ -1,2 +1,1 @@
-require "omniauth/strategies/wechat"
-require "omniauth/strategies/wechat_qiye"
+require "omniauth/wechat"

--- a/lib/omniauth/wechat.rb
+++ b/lib/omniauth/wechat.rb
@@ -1,0 +1,2 @@
+require "omniauth/strategies/wechat"
+require "omniauth/strategies/wechat_qiye"


### PR DESCRIPTION
Load errors in the console happen otherwise

```ruby
Could not find matching strategy for :wechat. You may need to install an additional gem (such as omniauth-wechat). (LoadError)
```

The apple omniauth gem needed to do the same https://github.com/nhosoya/omniauth-apple/pull/4 and many other gems follow the same approach. However, I don't fully understand why this is happening but confirmed that this does fix the issue for us.